### PR TITLE
 Integrate inspection tests into the normal test suite 

### DIFF
--- a/tests/Inspection.hs
+++ b/tests/Inspection.hs
@@ -1,12 +1,28 @@
 {-# language TemplateHaskell #-}
 {-# options_ghc -O -fplugin Test.Inspection.Plugin #-}
-module Inspection where
+module Inspection(inspect_tests) where
 
 import CFG (CFG(..), makeParser)
 import Library (many, (<.), (.>))
 import qualified LMS as LMS
 import qualified LibraryLMS as LMS
 import Test.Inspection
+
+import Test.Tasty (defaultMain, testGroup, TestTree)
+import Test.Tasty.HUnit (testCase, (@?=), assertFailure)
+
+mkUnitTest :: String -> Result -> TestTree
+mkUnitTest s r = testCase s assertion
+  where
+    assertion =
+      case r of
+        Success v -> return ()
+        Failure reason -> assertFailure reason
+
+inspect_tests :: TestTree
+inspect_tests = testGroup "inspection tests" [parseAorBs_test
+                                             , parseAlternate_test
+                                             , parseBrackets_test ]
 
 parseAorBsGen, parseAorBsCompile, parseAorBsHand :: String -> Maybe (String, [Char])
 parseAorBsGen = $$(makeParser (many $ Or () (Char () 'a') (Char () 'b')))
@@ -25,8 +41,12 @@ parseAorBsHand str@(c:cs) =
         Just (cs', r) -> Just (cs', c:r)
     _   -> Just (str, [])
 
-inspect ('parseAorBsGen === 'parseAorBsHand)
-inspect ('parseAorBsCompile === 'parseAorBsHand)
+
+parseAorBs_test :: TestTree
+parseAorBs_test =
+  testGroup "parseAorBs" $
+  [ mkUnitTest "gen" $(inspectTest ('parseAorBsGen === 'parseAorBsHand))
+  , mkUnitTest "lms" $(inspectTest ('parseAorBsCompile === 'parseAorBsHand)) ]
 
 
 parseAlternateGen, parseAlternateCompile, parseAlternateHand :: [Char] -> Maybe ([Char], ())
@@ -132,8 +152,11 @@ parseAlternateHand = go0
             Nothing -> Nothing
         _ -> Just (l, ())
 
-inspect ('parseAlternateGen ==- 'parseAlternateHand)
-inspect ('parseAlternateCompile ==- 'parseAlternateHand)
+parseAlternate_test :: TestTree
+parseAlternate_test =
+  testGroup "parseAlternate"
+    [ mkUnitTest "gen" $(inspectTest ('parseAlternateGen ==- 'parseAlternateHand))
+    , mkUnitTest "lms" $(inspectTest ('parseAlternateCompile ==- 'parseAlternateHand)) ]
 
 
 parseBracketsGen, parseBracketsCompile, parseBracketsHand :: String -> Maybe (String, ())
@@ -174,5 +197,8 @@ parseBracketsHand l@(x:xs) =
         Nothing -> Nothing
     _ -> Just (l, ())
 
-inspect ('parseBracketsGen === 'parseBracketsHand)
-inspect ('parseBracketsCompile === 'parseBracketsHand)
+parseBrackets_test :: TestTree
+parseBrackets_test =
+  testGroup "parseBrackets" $
+    [mkUnitTest "gen" $(inspectTest ('parseBracketsGen === 'parseBracketsHand))
+    , mkUnitTest "lms" $(inspectTest ('parseBracketsCompile === 'parseBracketsHand)) ]

--- a/tests/Inspection.hs
+++ b/tests/Inspection.hs
@@ -1,5 +1,6 @@
 {-# language TemplateHaskell #-}
 {-# options_ghc -O -fplugin Test.Inspection.Plugin #-}
+{-# OPTIONS_GHC -Wno-unused-matches #-}
 module Inspection(inspect_tests) where
 
 import CFG (CFG(..), makeParser)
@@ -8,15 +9,15 @@ import qualified LMS as LMS
 import qualified LibraryLMS as LMS
 import Test.Inspection
 
-import Test.Tasty (defaultMain, testGroup, TestTree)
-import Test.Tasty.HUnit (testCase, (@?=), assertFailure)
+import Test.Tasty (testGroup, TestTree)
+import Test.Tasty.HUnit (testCase, assertFailure)
 
 mkUnitTest :: String -> Result -> TestTree
 mkUnitTest s r = testCase s assertion
   where
     assertion =
       case r of
-        Success v -> return ()
+        Success _ -> return ()
         Failure reason -> assertFailure reason
 
 inspect_tests :: TestTree

--- a/tests/tasty.hs
+++ b/tests/tasty.hs
@@ -6,10 +6,13 @@ import Test.Tasty.HUnit (testCase, (@?=))
 import qualified Test as T
 import qualified TestLMS as LMS
 
+import Inspection
+
 main :: IO ()
 main =
     defaultMain $ testGroup "all"
-      [testGroup "normal"
+      [ inspect_tests
+      , testGroup "normal"
         [ testCase "parseA success" $ T.parseA "a" @?= Just ("", 'a')
         , testCase "parseA failure" $ T.parseA "b" @?= Nothing
         , testCase "parseA suffix" $ T.parseA "ab" @?= Just ("b", 'a')


### PR DESCRIPTION
If you don't do this then an inspection test failure stops all
the other tests being run.