### PR TITLE
WIP: Use the lift-plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,10 @@
 language: nix
+sudo: required
+before_script:
+  - sudo mount -o remount,exec,size=4G,mode=755 /run/user || true
+  - sudo mkdir -p /etc/nix
+  - echo "trusted-users = root $USER" | sudo tee -a /etc/nix/nix.conf
+  - sudo launchctl kickstart -k system/org.nixos.nix-daemon || true
 script:
 - nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/db557aab7b690f5e0e3348459f2e4dc8fd0d9298
 - cachix use mpickering

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: nix
-script: nix-build --argstr compiler ghc843
+script:
+- nix-env -iA cachix -f https://github.com/NixOS/nixpkgs/tarball/db557aab7b690f5e0e3348459f2e4dc8fd0d9298
+- cachix use mpickering
+- nix-build
 branches:
   only:
   - master

--- a/default.nix
+++ b/default.nix
@@ -6,12 +6,13 @@ let
 
   f = import ./typed-cfg.nix;
 
-  haskellPackages = if compiler == "default"
-                       then pkgs.haskellPackages
-                       else pkgs.haskell.packages.${compiler};
+  nixpkgs = import ./nixpkgs.nix {};
+  haskellPackages = nixpkgs.haskellPackages;
+
 
   hp = haskellPackages.extend( sel: sup: {
     dump-core = sel.callPackage ./nix/dump-core.nix {};
+    lift-plugin = sel.callPackage ./nix/lift-plugin.nix {};
     } );
 
   drv = hp.callPackage f {};

--- a/default.nix
+++ b/default.nix
@@ -15,7 +15,7 @@ let
     lift-plugin = sel.callPackage ./nix/lift-plugin.nix {};
     } );
 
-  drv = hp.callPackage f {};
+  drv = nixpkgs.haskell.lib.doCheck (hp.callPackage f {});
 
 in
 

--- a/nix/dump-core.nix
+++ b/nix/dump-core.nix
@@ -5,9 +5,9 @@ mkDerivation {
   pname = "dump-core";
   version = "0.1.3";
   src = fetchgit {
-    url = "https://github.com/mpickering/dump-core.git";
-    sha256 = "0him2330sf1s321zy857c8aaqlishlcknf1yi612cx86zgvs8axa";
-    rev = "52ac843d9369bebb69a6e068913cc90ed55de20d";
+    url = "https://github.com/mpickering/dump-core";
+    sha256 = "1mg8zh9ak91vdgm8i8ng9sbg79h66s5srf38jk5r0wga36m0k5al";
+    rev = "7cb4ec3d3eec5484a70224c8ca5a802b9a0c2f0b";
   };
   enableSeparateDataOutput = true;
   libraryHaskellDepends = [

--- a/nix/lift-plugin.nix
+++ b/nix/lift-plugin.nix
@@ -6,8 +6,8 @@ mkDerivation {
   version = "0.1.0.0";
   src = fetchgit {
     url = "https://github.com/mpickering/lift-plugin";
-    sha256 = "0b5c5lz3x38d2rnqb2qmp6ysw2kvh1m0a6ij0g4kf30nsp061pcd";
-    rev = "04aedad640573db9bc3d8f2c824ae79b968624d1";
+    sha256 = "0mjrqv0ikdf2kjalpm37pn6yln3y87g8ddi6az9hsy71bkh2w9i7";
+    rev = "e86c94a1bb27c848f9dcd7800ae9fb9e7f26e171";
   };
   postUnpack = "sourceRoot+=/lift-plugin; echo source root reset to $sourceRoot";
   libraryHaskellDepends = [

--- a/nix/lift-plugin.nix
+++ b/nix/lift-plugin.nix
@@ -1,0 +1,17 @@
+{ mkDerivation, base, fetchgit, ghc, ghc-tcplugins-extra, stdenv
+, syb, template-haskell
+}:
+mkDerivation {
+  pname = "lift-plugin";
+  version = "0.1.0.0";
+  src = fetchgit {
+    url = "https://github.com/mpickering/lift-plugin";
+    sha256 = "0b5c5lz3x38d2rnqb2qmp6ysw2kvh1m0a6ij0g4kf30nsp061pcd";
+    rev = "04aedad640573db9bc3d8f2c824ae79b968624d1";
+  };
+  postUnpack = "sourceRoot+=/lift-plugin; echo source root reset to $sourceRoot";
+  libraryHaskellDepends = [
+    base ghc ghc-tcplugins-extra syb template-haskell
+  ];
+  license = stdenv.lib.licenses.bsd3;
+}

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -5,5 +5,5 @@ in
     owner = "mpickering";
     repo = "head.hackage";
     # nixos-unstable as of 2017-11-13T08:53:10-00:00
-    rev = "e1ca51202d4259c1b83e342d4fe594484162889b";
-    sha256 = "1xqnzmvcyp9pp1pj30vmbmnsnc6swk221has86mlydgllsq0whyd"; })
+    rev = "7d86540897beaa439599e1241d0db0c780de7dc6";
+    sha256 = "0xrfabsf9jjms7gj7kjs5p3gk75dglrh177cacpv0lpxfxvj927r"; })

--- a/nixpkgs.nix
+++ b/nixpkgs.nix
@@ -1,0 +1,9 @@
+let
+  hostPkgs = import <nixpkgs> {};
+in
+  import (hostPkgs.fetchFromGitHub {
+    owner = "mpickering";
+    repo = "head.hackage";
+    # nixos-unstable as of 2017-11-13T08:53:10-00:00
+    rev = "e1ca51202d4259c1b83e342d4fe594484162889b";
+    sha256 = "1xqnzmvcyp9pp1pj30vmbmnsnc6swk221has86mlydgllsq0whyd"; })

--- a/typed-cfg.cabal
+++ b/typed-cfg.cabal
@@ -30,6 +30,7 @@ library
                      , lens >=4.15 && <4.17
                      , text
                      , bytestring
+                     , lift-plugin
   hs-source-dirs:      src
   ghc-options:         -O -Werror -Wincomplete-patterns
   default-language:    Haskell2010

--- a/typed-cfg.nix
+++ b/typed-cfg.nix
@@ -1,19 +1,23 @@
-{ mkDerivation, base, bytestring, criterion, dump-core
-, inspection-testing, lens, megaparsec, stdenv, tasty, tasty-hunit
-, template-haskell, text, lift-plugin
+{ mkDerivation, base, bytestring, criterion, dump-core, ghc
+, inspection-testing, lens, lift-plugin, megaparsec, stdenv, tasty
+, tasty-hunit, template-haskell, text
 }:
 mkDerivation {
   pname = "typed-cfg";
   version = "0.1.0.0";
   src = ./.;
+  configureFlags = [ "-fdump-core" ];
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring lens template-haskell text lift-plugin
+    base bytestring dump-core ghc lens lift-plugin template-haskell
+    text
   ];
   executableHaskellDepends = [
-    base bytestring criterion megaparsec text
+    base bytestring criterion dump-core megaparsec text
   ];
-  testHaskellDepends = [ base inspection-testing tasty tasty-hunit ];
+  testHaskellDepends = [
+    base dump-core inspection-testing tasty tasty-hunit
+  ];
   license = stdenv.lib.licenses.bsd3;
 }

--- a/typed-cfg.nix
+++ b/typed-cfg.nix
@@ -1,6 +1,6 @@
 { mkDerivation, base, bytestring, criterion, dump-core
 , inspection-testing, lens, megaparsec, stdenv, tasty, tasty-hunit
-, template-haskell, text
+, template-haskell, text, lift-plugin
 }:
 mkDerivation {
   pname = "typed-cfg";
@@ -9,11 +9,11 @@ mkDerivation {
   isLibrary = true;
   isExecutable = true;
   libraryHaskellDepends = [
-    base bytestring dump-core lens template-haskell text
+    base bytestring lens template-haskell text lift-plugin
   ];
   executableHaskellDepends = [
-    base bytestring criterion dump-core megaparsec text
+    base bytestring criterion megaparsec text
   ];
-  testHaskellDepends = [ base dump-core inspection-testing tasty tasty-hunit ];
+  testHaskellDepends = [ base inspection-testing tasty tasty-hunit ];
   license = stdenv.lib.licenses.bsd3;
 }


### PR DESCRIPTION
Enabling the plugin that I wrote means that we can get rid of quite a lot of boilerplate. 

The plugin looks for calls of `pure foo` and then if `foo` is a top level function it creates the special
lift dictionary `\_ -> [|| foo ||]`. This is similar to the code we had before where the user had to supply both `a` and `Code a` but the `Code a` parameter is provided implicitly. 

To try this you should use `cachix` in order to avoid having to build GHC from source.

```
cachix use mpickering
nix-shell
cabal build
```